### PR TITLE
fix: persist Chromium session data across addon restarts

### DIFF
--- a/config/supervisor/5-chromium.conf
+++ b/config/supervisor/5-chromium.conf
@@ -1,6 +1,6 @@
 [program:Chromium]
-command=bash -c 'mkdir -p /config/google-chrome
-  touch "/config/google-chrome/First Run" && chromium --guest --kiosk --no-sandbox --test-type --no-first-run --disable-dev-shm-usage --start-maximized --noerrdialogs --user-data-dir=/config/google-chrome $(jq --raw-output ".url // \"http://homeassistant:8123\"" /data/options.json)'
+command=bash -c 'mkdir -p /data/google-chrome
+  touch "/data/google-chrome/First Run" && chromium --kiosk --no-sandbox --test-type --no-first-run --disable-dev-shm-usage --start-maximized --noerrdialogs --user-data-dir=/data/google-chrome $(jq --raw-output ".url // \"http://homeassistant:8123\"" /data/options.json)'
 priority=5
 autorestart=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
## Summary

Fixes the issue where Home Assistant login sessions are lost every time the addon or HAOS restarts, requiring users to re-authenticate on their kiosk/tablet device.

Two bugs in `5-chromium.conf` caused this:

1. **`--guest` flag** — Guest mode explicitly discards all cookies, session storage, and browsing data. Even if the user checks "Keep me logged in", guest mode throws it away.

2. **`--user-data-dir=/config/google-chrome`** — The `/config/` directory is inside the container's ephemeral filesystem (populated by `COPY config /config` in the Dockerfile). It is wiped and recreated fresh on every container restart. The HA addon persistent volume is `/data/`, not `/config/`.

## Changes

- Remove `--guest` flag so Chromium saves cookies and session data normally
- Change `--user-data-dir` from `/config/google-chrome` to `/data/google-chrome` so profile data persists across restarts

## Testing

After this fix, log into Home Assistant once with "Keep me logged in" checked. The session persists through:
- Addon restart
- HAOS reboot
- Addon rebuild

Tested on a real HAOS instance with an iPad 2 connecting via noVNC.